### PR TITLE
fix for incorrect number of deletions when no insertions

### DIFF
--- a/Decombinator.py
+++ b/Decombinator.py
@@ -305,7 +305,7 @@ def vanalysis(read):
         counts['no_vtags_found'] += 1
         return
       
-def janalysis(read):
+def janalysis(read, end_of_v):
   
   hold_j = j_key.findall(read)
   
@@ -319,7 +319,7 @@ def janalysis(read):
     
     j_seq_end = hold_j[0][1] + len(hold_j[0][0])      
         
-    start_j_j_dels = get_j_deletions( read, j_match, temp_start_j, j_regions )
+    start_j_j_dels = get_j_deletions( read, j_match, temp_start_j, j_regions, end_of_v )
     
     if start_j_j_dels: # If the number of deletions has been found
       return j_match, start_j_j_dels[0], start_j_j_dels[1], j_seq_end
@@ -337,7 +337,7 @@ def janalysis(read):
               j_match = k
               temp_start_j = hold_j1[i][1] - jump_to_start_j[j_match] # Finds where the start of a full J would be
               j_seq_end = hold_j1[i][1] + len(hold_j1[i][0]) + j_half_split                                              
-              start_j_j_dels = get_j_deletions( read, j_match, temp_start_j, j_regions )
+              start_j_j_dels = get_j_deletions( read, j_match, temp_start_j, j_regions, end_of_v )
               if start_j_j_dels:
                 return j_match, start_j_j_dels[0], start_j_j_dels[1], j_seq_end
       counts['foundj1notj2'] += 1
@@ -355,7 +355,7 @@ def janalysis(read):
                 j_match = k
                 temp_start_j = hold_j2[i][1] - jump_to_start_j[j_match] - j_half_split # Finds where the start of a full J would be
                 j_seq_end = hold_j2[i][1] + len(hold_j2[i][0])                                                
-                start_j_j_dels = get_j_deletions( read, j_match, temp_start_j, j_regions )
+                start_j_j_dels = get_j_deletions( read, j_match, temp_start_j, j_regions, end_of_v )
                 if start_j_j_dels:
                   return j_match, start_j_j_dels[0], start_j_j_dels[1], j_seq_end
         counts['foundv2notv1'] += 1
@@ -378,7 +378,8 @@ def dcr(read, inputargs):
   if not vdat:
     return
 
-  jdat = janalysis(read)
+  end_of_v = vdat[1] + 1
+  jdat = janalysis(read, end_of_v)
   
   if jdat:
     
@@ -551,7 +552,7 @@ def get_v_deletions( read, v_match, temp_end_v, v_regions_cut ):
         counts['v_del_failed'] += 1
         return 
 
-def get_j_deletions( read, j_match, temp_start_j, j_regions_cut ):
+def get_j_deletions( read, j_match, temp_start_j, j_regions_cut, end_of_v ):
     # This function determines the number of J deletions in sequence read
     # by comparing it to j_match, beginning by making comparisons at the
     # end of j_match and at position temp_end_j in read.
@@ -560,7 +561,12 @@ def get_j_deletions( read, j_match, temp_start_j, j_regions_cut ):
     is_j_match = 0
     while is_j_match == 0 and 0 <= function_temp_start_j+2 < len(str(read)):
         # Require a 10 base match to determine where end of germ-line sequence lies
-        if str(j_regions_cut[j_match])[pos:pos+10] == read[function_temp_start_j:function_temp_start_j+10]:
+        
+        if function_temp_start_j < end_of_v:
+          pos += 1
+          function_temp_start_j += 1
+
+        elif str(j_regions_cut[j_match])[pos:pos+10] == read[function_temp_start_j:function_temp_start_j+10]:
             is_j_match = 1
             deletions_j = pos
             start_j = function_temp_start_j
@@ -704,7 +710,7 @@ if __name__ == '__main__':
           if not recom:
             recom = dcr(vdj, inputargs)
             frame = 'forward'
-                        
+     
         if recom:
           counts['vj_count'] += 1
           vdjqual = qual[bclength:]  

--- a/Decombinator.py
+++ b/Decombinator.py
@@ -560,12 +560,12 @@ def get_j_deletions( read, j_match, temp_start_j, j_regions_cut, end_of_v ):
     pos = 0
     is_j_match = 0
     while is_j_match == 0 and 0 <= function_temp_start_j+2 < len(str(read)):
-        # Require a 10 base match to determine where end of germ-line sequence lies
-        
+        # in the case of no detectable insertions, where nucleotide junctions could be derived from either gene,
+        # nucleotides will be deemed to have derived from the V gene, and count towards deletions from J. 
         if function_temp_start_j < end_of_v:
           pos += 1
           function_temp_start_j += 1
-
+        # Require a 10 base match to determine where end of germ-line sequence lies
         elif str(j_regions_cut[j_match])[pos:pos+10] == read[function_temp_start_j:function_temp_start_j+10]:
             is_j_match = 1
             deletions_j = pos

--- a/README.md
+++ b/README.md
@@ -170,7 +170,9 @@ All DCR-containing output files are comma-delimited, with the fields of that fiv
 * Number of J deletions
 * Insert sequence (the nucleotide sequence between end of deleted V and J)
 
-The V and J indices are arbitrary numbers based on the order of the tag sequences in the relevant tag file (using Python indexing, which starts at 0 rather than 1). Also note that the number of V and J deletions actually just represents how many bases have been removed from the end of that particular germline gene (as given in the germline FASTA files in the additional file repo); it is entirely possible that more bases where actually deleted, and just that the same bases have been re-added. 
+The V and J indices are arbitrary numbers based on the order of the tag sequences in the relevant tag file (using Python indexing, which starts at 0 rather than 1). Also note that the number of V and J deletions actually just represents how many bases have been removed from the end of that particular germline gene (as given in the germline FASTA files in the additional file repo); it is entirely possible that more bases where actually deleted, and just that the same bases have been re-added.
+
+Additionally there are low frequencies of (predominantly alpha chain) recombinations where there is no detectable insertion, and where the nucleotides at the junction between the germline V and J genes could have derived from either. In such circumstances the nucleotides will arbitrarily be deemed to have derived from the V gene, and thus count towards deletions from the J, however it is impossible to know which gene originally contributed these residues.
 
 Various additional fields may follow the five part classifier, but the DCR will always occupy the first five positions. An example identifier, from a human alpha chain file, might look like this:
 


### PR DESCRIPTION
Addresses edge case for CDR3s with no insertions. 

Originally V and J deletions were determined independently, but for cases where there is no insertion, there can be problems where V and J appear to overlap.

Issue is fixed by reading in the end of V position when determining J deletions, and adding to the deletion count correspondingly.