### PR TITLE
Handle empty output from decombinator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ decombinator.egg-info
 .decombinatorenv
 build/
 .vscode
+.venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,9 @@ pythonpath = [
   "./src"
 ]
 
+[tool.black]
+line-length = 79
+
 [project.scripts]
 decombinator = "decombinator.pipeline:main"
 

--- a/src/decombinator/collapse.py
+++ b/src/decombinator/collapse.py
@@ -95,6 +95,7 @@ def check_dcr_file(infile, opener):
     if os.path.isfile(infile) == False:
         print("Cannot find file, please double-check path.")
         return False
+    print(os.path.getsize(infile))
     if os.path.getsize(infile) == 0:
         print("Input file appears to be empty; please double-check path.")
         return False
@@ -107,8 +108,8 @@ def check_dcr_file(infile, opener):
             try:
                 nextline = next(poss_dcr)
             except StopIteration:
-                print(
-                    "Input Decombinator file sanity check warning: less than five lines in input file."
+                raise StopIteration(
+                    f"Input Decombinator file sanity check warning: {i} line(s) in input file."
                 )
 
             if "," not in nextline:
@@ -490,7 +491,7 @@ def read_in_data(
         data = opener(data, "rt")
 
     if not data:
-        raise TypeError(
+        raise ValueError(
             "No reads found in input file. Check .n12 and log files for errors."
         )
 

--- a/src/decombinator/collapse.py
+++ b/src/decombinator/collapse.py
@@ -97,8 +97,7 @@ def check_dcr_file(infile, opener):
         return False
     print(os.path.getsize(infile))
     if os.path.getsize(infile) == 0:
-        print("Input file appears to be empty; please double-check path.")
-        return False
+        raise ValueError("Input file appears to be empty; please double-check path.")
 
     # Check first few lines
     with opener(infile, "rt") as poss_dcr:

--- a/tests/test_collapse.py
+++ b/tests/test_collapse.py
@@ -1,7 +1,6 @@
 import collections as coll
-
-from pyrepseq.util import subprocess
 import pathlib
+
 import pytest
 
 from decombinator import collapse
@@ -173,7 +172,7 @@ class TestFindFirstSpacer:
 
 
 class TestReadInData:
-    
+
     collapse.counts = coll.Counter()
 
     @pytest.fixture
@@ -186,12 +185,17 @@ class TestReadInData:
 
     def test_no_dcr(self, blank_input, pipe_args):
         with pytest.raises(ValueError):
-            collapse.read_in_data(blank_input, pipe_args, None, None, None, None)
+            collapse.read_in_data(
+                blank_input, pipe_args, None, None, None, None
+            )
+
 
 class TestCheckDcrFile:
 
     @pytest.fixture(scope="class")
-    def output_dir(self, tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
+    def output_dir(
+        self, tmp_path_factory: pytest.TempPathFactory
+    ) -> pathlib.Path:
         output_dir = tmp_path_factory.mktemp("output")
         return output_dir
 
@@ -205,8 +209,5 @@ class TestCheckDcrFile:
         empty_filepath.write_text(output)
 
     def test_empty_n12(self, empty_file, empty_filepath: pathlib.Path) -> None:
-        print(empty_filepath)
-        with empty_filepath.open() as f:
-            print(f.readline())
         with pytest.raises(ValueError):
             collapse.check_dcr_file(empty_filepath, open)

--- a/tests/test_collapse.py
+++ b/tests/test_collapse.py
@@ -1,5 +1,6 @@
 import collections as coll
 
+from pyrepseq.util import subprocess
 import pytest
 
 from decombinator import collapse
@@ -176,16 +177,33 @@ class TestReadInData:
 
     @pytest.fixture
     def blank_input(self):
-        return [""]
+        return []
 
     @pytest.fixture
-    def args(self):
+    def pipe_args(self):
         return {"command": "pipeline"}
 
-    def test_no_dcr(self, blank_input, args):
-        with pytest.raises(TypeError):
-            collapse.read_in_data(blank_input, args, None, None, None, None)
+    def test_no_dcr(self, blank_input, pipe_args):
+        with pytest.raises(ValueError):
+            collapse.read_in_data(blank_input, pipe_args, None, None, None, None)
 
-    def test_no_dcr_wrong(self, blank_input, args):
-        with pytest.raises(UnboundLocalError):
-            collapse.read_in_data(blank_input, args, None, None, None, None)
+# class TestCheckDcrFile:
+#
+#     @pytest.fixture(scope="class")
+#     def output_dir(tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
+#         # Create a temporary output directory
+#         output_dir = tmp_path_factory.mktemp("output")
+#         return output_dir
+#
+#     @pytest.fixture
+#     def empty_file(output_dir):
+#         name = "empty.n12"
+#         filepath = output_dir / name
+#         output = ""
+#         with filepath.open("w", encoding ="utf-8") as f:
+#             f.write(output)
+#
+#
+#     def test_empty_n12(self, empty_f):
+#         with pytest.raises(StopIteration):
+#             collapse.check_dcr_file(empty_f, open)

--- a/tests/test_collapse.py
+++ b/tests/test_collapse.py
@@ -166,3 +166,8 @@ class TestFindFirstSpacer:
         assert collapse.findFirstSpacer(oligo, seq, oligo_start, oligo_end) == [
             oligo["spcr1"]
         ]
+
+class TestReadInData:
+
+    def test_no_dcr(self):
+        pass

--- a/tests/test_collapse.py
+++ b/tests/test_collapse.py
@@ -192,19 +192,21 @@ class TestCheckDcrFile:
 
     @pytest.fixture(scope="class")
     def output_dir(self, tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
-        # Create a temporary output directory
         output_dir = tmp_path_factory.mktemp("output")
         return output_dir
 
     @pytest.fixture
-    def empty_file(self, output_dir):
-        name = "empty.n12"
-        filepath = output_dir / name
+    def empty_filepath(self, output_dir: pathlib.Path) -> pathlib.Path:
+        return output_dir / "empty.n12"
+
+    @pytest.fixture
+    def empty_file(self, empty_filepath: pathlib.Path) -> None:
         output = ""
-        with filepath.open("w", encoding ="utf-8") as f:
-            f.write(output)
+        empty_filepath.write_text(output)
 
-
-    def test_empty_n12(self, empty_file):
-        with pytest.raises(StopIteration):
-            collapse.check_dcr_file(empty_file, open)
+    def test_empty_n12(self, empty_file, empty_filepath: pathlib.Path) -> None:
+        print(empty_filepath)
+        with empty_filepath.open() as f:
+            print(f.readline())
+        with pytest.raises(ValueError):
+            collapse.check_dcr_file(empty_filepath, open)

--- a/tests/test_collapse.py
+++ b/tests/test_collapse.py
@@ -1,6 +1,8 @@
-from decombinator import collapse
 import collections as coll
+
 import pytest
+
+from decombinator import collapse
 
 
 class TestClusterUMIs:
@@ -125,9 +127,9 @@ class TestFindFirstSpacer:
         allowance = 10
         oligo_end = allowance + len(oligo["spcr1"])
 
-        assert collapse.findFirstSpacer(oligo, seq, oligo_start, oligo_end) == [
-            oligo["spcr1"]
-        ]
+        assert collapse.findFirstSpacer(
+            oligo, seq, oligo_start, oligo_end
+        ) == [oligo["spcr1"]]
 
     def test_i8(self):
         oligo = {
@@ -138,9 +140,9 @@ class TestFindFirstSpacer:
         allowance = 10
         oligo_end = allowance + len(oligo["spcr1"])
 
-        assert collapse.findFirstSpacer(oligo, seq, oligo_start, oligo_end) == [
-            oligo["spcr1"]
-        ]
+        assert collapse.findFirstSpacer(
+            oligo, seq, oligo_start, oligo_end
+        ) == [oligo["spcr1"]]
 
     def test_i8_single(self):
         oligo = {
@@ -151,9 +153,9 @@ class TestFindFirstSpacer:
         allowance = 10
         oligo_end = allowance + len(oligo["spcr1"])
 
-        assert collapse.findFirstSpacer(oligo, seq, oligo_start, oligo_end) == [
-            oligo["spcr1"]
-        ]
+        assert collapse.findFirstSpacer(
+            oligo, seq, oligo_start, oligo_end
+        ) == [oligo["spcr1"]]
 
     def test_nebio(self):
         oligo = {
@@ -163,11 +165,27 @@ class TestFindFirstSpacer:
         oligo_start = 18
         oligo_end = oligo_start + 10
 
-        assert collapse.findFirstSpacer(oligo, seq, oligo_start, oligo_end) == [
-            oligo["spcr1"]
-        ]
+        assert collapse.findFirstSpacer(
+            oligo, seq, oligo_start, oligo_end
+        ) == [oligo["spcr1"]]
+
 
 class TestReadInData:
+    
+    collapse.counts = coll.Counter()
 
-    def test_no_dcr(self):
-        pass
+    @pytest.fixture
+    def blank_input(self):
+        return [""]
+
+    @pytest.fixture
+    def args(self):
+        return {"command": "pipeline"}
+
+    def test_no_dcr(self, blank_input, args):
+        with pytest.raises(TypeError):
+            collapse.read_in_data(blank_input, args, None, None, None, None)
+
+    def test_no_dcr_wrong(self, blank_input, args):
+        with pytest.raises(UnboundLocalError):
+            collapse.read_in_data(blank_input, args, None, None, None, None)

--- a/tests/test_collapse.py
+++ b/tests/test_collapse.py
@@ -1,6 +1,7 @@
 import collections as coll
 
 from pyrepseq.util import subprocess
+import pathlib
 import pytest
 
 from decombinator import collapse
@@ -187,23 +188,23 @@ class TestReadInData:
         with pytest.raises(ValueError):
             collapse.read_in_data(blank_input, pipe_args, None, None, None, None)
 
-# class TestCheckDcrFile:
-#
-#     @pytest.fixture(scope="class")
-#     def output_dir(tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
-#         # Create a temporary output directory
-#         output_dir = tmp_path_factory.mktemp("output")
-#         return output_dir
-#
-#     @pytest.fixture
-#     def empty_file(output_dir):
-#         name = "empty.n12"
-#         filepath = output_dir / name
-#         output = ""
-#         with filepath.open("w", encoding ="utf-8") as f:
-#             f.write(output)
-#
-#
-#     def test_empty_n12(self, empty_f):
-#         with pytest.raises(StopIteration):
-#             collapse.check_dcr_file(empty_f, open)
+class TestCheckDcrFile:
+
+    @pytest.fixture(scope="class")
+    def output_dir(self, tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
+        # Create a temporary output directory
+        output_dir = tmp_path_factory.mktemp("output")
+        return output_dir
+
+    @pytest.fixture
+    def empty_file(self, output_dir):
+        name = "empty.n12"
+        filepath = output_dir / name
+        output = ""
+        with filepath.open("w", encoding ="utf-8") as f:
+            f.write(output)
+
+
+    def test_empty_n12(self, empty_file):
+        with pytest.raises(StopIteration):
+            collapse.check_dcr_file(empty_file, open)


### PR DESCRIPTION
**Issue:** When run in pipeline mode, if there are no TCRs found by decombinator, the `if not data` statement in collapse does not check for zero input TCRs and therefore fails ungracefully with an UnboundLocalError.

**Solution:** Write unit test for read_in_data that raises a ValueError if there are no TCRs found in the output of decombinator.

Additionally, PR improves verbosity of error when reading an empty `.n12` file in collapse mode.