### PR TITLE
Handle empty FASTQ files gracefully

### DIFF
--- a/src/decombinator/decombine.py
+++ b/src/decombinator/decombine.py
@@ -95,7 +95,6 @@
 ##################
 from __future__ import division
 
-import argparse
 import collections as coll
 import gzip
 import itertools
@@ -105,7 +104,6 @@ import sys
 import urllib
 from importlib import metadata
 from time import strftime, time
-from typing import Any
 
 import Levenshtein as lev
 from acora import AcoraBuilder

--- a/src/decombinator/decombine.py
+++ b/src/decombinator/decombine.py
@@ -94,21 +94,23 @@
 #### PACKAGES ####
 ##################
 from __future__ import division
-import sys
-import os
-import itertools
-from typing import Any
-import urllib
-import string
-import collections as coll
+
 import argparse
+import collections as coll
 import gzip
+import itertools
+import os
+import string
+import sys
+import urllib
+from importlib import metadata
+from time import strftime, time
+from typing import Any
+
 import Levenshtein as lev
+from acora import AcoraBuilder
 from Bio import SeqIO
 from Bio.Seq import Seq
-from acora import AcoraBuilder
-from time import time, strftime
-from importlib import metadata
 
 ##########################################################
 ############# FASTQ SANITY CHECK AND PARSING #############
@@ -134,14 +136,14 @@ def fastq_check(inputargs, opener, samplenam, summaryname):
             # Log of empty file required for pipeline
             if inputargs["suppresssummary"] == False:
                 inout_name = (
-                    "_".join(f"{samplenam}".split("_")[:-1]) + f"_{chainnams[chain]}"
+                    "_".join(f"{samplenam}".split("_")[:-1])
+                    + f"_{chainnams[chain]}"
                 )
                 summstr = (
-                    "OutputFile," + inout_name
-                    + "\nNumberReadsInput," + "0"
+                    "OutputFile," + inout_name + "\nNumberReadsInput," + "0"
                 )
             if not os.path.exists(summaryname):
-                        summaryfile = open(summaryname, "wt")
+                summaryfile = open(summaryname, "wt")
             else:
                 # If one exists, start an incremental day stamp
                 for i in range(2, 10000):
@@ -347,7 +349,9 @@ def vanalysis(read):
                                 hold_v2[i][1]
                                 - v_half_split : hold_v2[i][1]
                                 - v_half_split
-                                + len(v_seqs[half2_v_seqs.index(hold_v2[i][0])])
+                                + len(
+                                    v_seqs[half2_v_seqs.index(hold_v2[i][0])]
+                                )
                             ]
                         ):
                             if (
@@ -448,7 +452,11 @@ def janalysis(read, end_of_v):
                                 + j_half_split
                             )
                             start_j_j_dels = get_j_deletions(
-                                read, j_match, temp_start_j, j_regions, end_of_v
+                                read,
+                                j_match,
+                                temp_start_j,
+                                j_regions,
+                                end_of_v,
                             )
                             if start_j_j_dels:
                                 return (
@@ -475,7 +483,9 @@ def janalysis(read, end_of_v):
                                 hold_j2[i][1]
                                 - j_half_split : hold_j2[i][1]
                                 - j_half_split
-                                + len(j_seqs[half2_j_seqs.index(hold_j2[i][0])])
+                                + len(
+                                    j_seqs[half2_j_seqs.index(hold_j2[i][0])]
+                                )
                             ]
                         ):
                             if (
@@ -920,7 +930,7 @@ def decombinator(inputargs: dict) -> list:
     print("Decombining FASTQ data...")
 
     suffix = "." + inputargs["extension"]
-    
+
     # If chain had not been autodetected, write it out into output file
     if counts["chain_detected"] == 1:
         name_results = inputargs["prefix"] + samplenam
@@ -1077,8 +1087,8 @@ def decombinator(inputargs: dict) -> list:
                 )
                 if not os.path.exists(summaryname):
                     summaryfile = open(summaryname, "wt")
-                    break       
-        
+                    break
+
         inout_name = (
             "_".join(f"{samplenam}".split("_")[:-1]) + f"_{chainnams[chain]}"
         )

--- a/src/decombinator/decombine.py
+++ b/src/decombinator/decombine.py
@@ -93,7 +93,6 @@
 ##################
 #### PACKAGES ####
 ##################
-# print("TEST1")
 from __future__ import division
 import sys
 import os
@@ -235,9 +234,6 @@ def readfq(fp):
             for l in fp:  # search for the start of the next record
                 if l[0] in ">@":  # fasta/q header line
                     last = l[:-1]  # save this line
-                    # i = i + 1
-                    # if i % 100000 == 0:
-                    # print(i)
                     break
         if not last:
             break
@@ -253,7 +249,6 @@ def readfq(fp):
                 break
         else:  # this is a fastq record
             seq, leng, seqs = "".join(seqs), 0, []
-            # print(seq)
             for l in fp:  # read the quality
                 seqs.append(l[:-1])
                 leng += len(l) - 1
@@ -961,7 +956,6 @@ def decombinator(inputargs: dict) -> list:
         zipfqs = zip(fq1, fq2)
 
         for records in zipfqs:
-            # print(records)
             record1, record2 = records
             if inputargs["bc_read"] == "R2":
                 readid = record1[0]
@@ -976,7 +970,6 @@ def decombinator(inputargs: dict) -> list:
                 vdjqual = record1[2][bclength:]
                 bc = record1[1][0:bclength]
                 bcQ = record1[2][0:bclength]
-                # print(bc)
 
             if inputargs["nobarcoding"] == False:
                 if (
@@ -985,7 +978,6 @@ def decombinator(inputargs: dict) -> list:
                     counts["dcrfilter_barcodeN"] += 1
 
             counts["read_count"] += 1
-            # print(counts['read_count'])
             if (
                 counts["read_count"] % 100000 == 0
                 and inputargs["dontcount"] == False
@@ -1007,7 +999,6 @@ def decombinator(inputargs: dict) -> list:
                     frame = "forward"
 
             if recom:
-                # print("TEST1")
                 counts["vj_count"] += 1
 
                 if frame == "reverse":

--- a/src/decombinator/decombine.py
+++ b/src/decombinator/decombine.py
@@ -123,7 +123,7 @@ def opener_check(inputargs):
         return open
 
 
-def fastq_check(inputargs, opener, samplenam, summaryname):
+def fastq_check(inputargs, opener, samplenam, summaryname, logpath):
     """fastq_check(file): Performs a rudimentary sanity check to see whether a file is indeed a FASTQ file"""
 
     success = True
@@ -144,6 +144,7 @@ def fastq_check(inputargs, opener, samplenam, summaryname):
                 summaryfile = open(summaryname, "wt")
             else:
                 # If one exists, start an incremental day stamp
+                date = strftime("%Y_%m_%d")
                 for i in range(2, 10000):
                     summaryname = logpath + date + "_"
                     if inputargs["chain"]:
@@ -908,7 +909,10 @@ def decombinator(inputargs: dict) -> list:
 
     # Brief FASTQ sanity check
     if inputargs["dontcheck"] == False:
-        if not fastq_check(inputargs, opener, samplenam, summaryname) == True:
+        if (
+            not fastq_check(inputargs, opener, samplenam, summaryname, logpath)
+            == True
+        ):
             print(
                 "FASTQ sanity check failed reading",
                 inputargs["infile"],

--- a/src/decombinator/decombine.py
+++ b/src/decombinator/decombine.py
@@ -128,15 +128,13 @@ def fastq_check(infile, opener):
 
     success = True
 
-    # if infile.endswith('.gz'):
-    with opener(infile, "rt") as possfq:
-        try:
-            read = [i for i in itertools.islice(possfq, 0, 4)]
-        except:
-            print(
+    with opener(infile, "r") as possfq:
+        if sum(1 for _ in itertools.islice(possfq, 4)) < 4:
+            raise ValueError(
                 "There are fewer than four lines in this file, and thus it is not a valid FASTQ file. Please check input and try again."
             )
-            sys.exit()
+        else:
+            read = [i for i in itertools.islice(possfq, 0, 4)]
 
     # @ check
     if not read[0][0] == "@":

--- a/tests/test_decombine.py
+++ b/tests/test_decombine.py
@@ -55,6 +55,7 @@ class TestEmptyFq:
     def expected_log(self) -> str:
         return "OutputFile," + "empty_alpha" + "\nNumberReadsInput," + "0\n"
 
+    @pytest.fixture
     def test_empty_log(
         self, output_dir: pathlib.Path, test_empty_fq: None, expected_log: str
     ) -> None:
@@ -63,6 +64,31 @@ class TestEmptyFq:
             output_dir
             / "Logs"
             / f"{date}_alpha_empty_merge_Decombinator_Summary.csv"
+        )
+        with logfile.open() as log:
+            assert log.read() == expected_log
+
+    @pytest.fixture
+    def test_empty_fq_repeat(
+        self, pipe_args: dict[str, Any], test_empty_log: None
+    ) -> None:
+        with pytest.raises(ValueError):
+            decombine.decombinator(pipe_args)
+
+    # TODO: Test this logic independently. Due to logging design in Decombinator
+    # at present this must be tested in the empty fq case specifically
+    def test_2nd_log(
+        self,
+        output_dir: pathlib.Path,
+        test_empty_fq: None,
+        expected_log: str,
+        test_empty_fq_repeat: None,
+    ) -> None:
+        date = time.strftime("%Y_%m_%d")
+        logfile = (
+            output_dir
+            / "Logs"
+            / f"{date}_alpha_empty_merge_Decombinator_Summary2.csv"
         )
         with logfile.open() as log:
             assert log.read() == expected_log

--- a/tests/test_decombine.py
+++ b/tests/test_decombine.py
@@ -1,6 +1,10 @@
-import pytest
 import pathlib
+from typing import Any
+
+import pytest
+
 from decombinator import decombine
+
 
 class TestEmptyFq:
 
@@ -21,14 +25,28 @@ class TestEmptyFq:
         empty_filepath.write_text(output)
 
     @pytest.fixture
-    def pipe_args(self, empty_filepath):
+    def pipe_args(
+        self, output_dir: pathlib.Path, empty_filepath: pathlib.Path
+    ) -> dict[str, Any]:
         return {
             "command": "pipeline",
             "infile": str(empty_filepath.resolve()),
-            "dontcheck": False
+            "dontcheck": False,
+            "chain": "a",
+            "outpath": str(output_dir.resolve()),
         }
 
-    def test_empty_n12(self, empty_file, empty_filepath: pathlib.Path, pipe_args) -> None:
+    @pytest.fixture
+    def test_empty_fq(
+        self, empty_file: None, pipe_args: dict[str, Any]
+    ) -> None:
         with pytest.raises(ValueError):
             decombine.decombinator(pipe_args)
- 
+
+    def test_empty_log(
+        self, output_dir: pathlib.Path, test_empty_fq: None
+    ) -> None:
+        logfile = output_dir / "Logs" / "empty_Decombinator_Summary.csv"
+        with logfile.open() as log:
+            inputs = log.readline(21)
+            assert inputs == "NumberReadsInput,0"

--- a/tests/test_decombine.py
+++ b/tests/test_decombine.py
@@ -1,0 +1,34 @@
+import pytest
+import pathlib
+from decombinator import decombine
+
+class TestEmptyFq:
+
+    @pytest.fixture(scope="class")
+    def output_dir(
+        self, tmp_path_factory: pytest.TempPathFactory
+    ) -> pathlib.Path:
+        output_dir = tmp_path_factory.mktemp("output")
+        return output_dir
+
+    @pytest.fixture
+    def empty_filepath(self, output_dir: pathlib.Path) -> pathlib.Path:
+        return output_dir / "empty.fq"
+
+    @pytest.fixture
+    def empty_file(self, empty_filepath: pathlib.Path) -> None:
+        output = ""
+        empty_filepath.write_text(output)
+
+    @pytest.fixture
+    def pipe_args(self, empty_filepath):
+        return {
+            "command": "pipeline",
+            "infile": str(empty_filepath.resolve()),
+            "dontcheck": False
+        }
+
+    def test_empty_n12(self, empty_file, empty_filepath: pathlib.Path, pipe_args) -> None:
+        with pytest.raises(ValueError):
+            decombine.decombinator(pipe_args)
+ 


### PR DESCRIPTION
**Issue:** Decombinator fails ungracefully if no lines exist in the FASTQ file. This has been noticed now due to the new [VSearch pipeline](https://github.com/innate2adaptive/Decombinator-Tools/pull/8) as the result of a bad VSearch merge that will output an empty FASTQ.

**Solution:** Decombinator now has a helpful error message if the FASTQ file supplied is empty. For pipeline use, the error is also output to a log file.