### PR TITLE
Make GitHub release independent of pypi action

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -67,7 +67,7 @@ jobs:
     name: >-
       signed-github-release ✍️
     needs:
-    - publish-to-pypi
+    - build
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
Fixes an issue with the workflow dispatch mode of the release action.