### PR TITLE
Permit test pypi upload with no local versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,8 @@ requires = ["setuptools>=64", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+version_scheme = "post-release"
+local_scheme = "no-local-version"
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
This PR makes setuptools drop the local version suffix so that TestPyPI will accept the upload.